### PR TITLE
added background call to server.py and call to django runserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,8 @@ COPY certs/* /app/certs/
 COPY backend/* /app/
 
 ENV PORT 50051
-CMD python server.py
+
+EXPOSE 80
+EXPOSE 50051
+
+CMD  python server.py & python manage.py runserver 0.0.0.0:80


### PR DESCRIPTION
Closes #7 

`python server.py` throws an error on master

```
Traceback (most recent call last):
  File "server.py", line 11, in <module>
    import history_pb2
ModuleNotFoundError: No module named 'history_pb2'
```

So I wasn't able to test it fully. But it should work fine once that's resolved.