### PR TITLE
Enable Support for Automatically Redacting Shell History

### DIFF
--- a/main.go
+++ b/main.go
@@ -67,6 +67,20 @@ func initConfig() Config {
 	return config
 }
 
+// Transforms a source string into a new (and possibly different) output string.
+type Transformer interface {
+	transform(input string) (output string)
+}
+
+// Represents a filter that maps a regex key to a regex transformation.
+type RedactionFilter map[string]string
+
+// Transforms source string to and output string when it matches a defined
+// redaction.
+func (filter *RedactionFilter) transform(source string) (result string) {
+	return source
+}
+
 func connect(address string) (*grpc.ClientConn, error) {
 	// Let's embed the certificate
 	box := packr.NewBox("./certs")

--- a/main.go
+++ b/main.go
@@ -56,10 +56,10 @@ func initConfig() Config {
 		}
 		log.Fatal(err)
 	} else {
-		//Read file.
+		// Read file.
 		byteValue, _ := ioutil.ReadAll(jsonFile)
 
-		//Convert json to Config struct.
+		// Convert json to Config struct.
 		json.Unmarshal(byteValue, &config)
 	}
 

--- a/main.go
+++ b/main.go
@@ -40,13 +40,13 @@ func initConfig() Config {
 	config.RemoteHost = "localhost"
 	config.RemotePort = 50051
 
-	user, err := user.Current()
+	currentUser, err := user.Current()
 	if err != nil {
 		log.Fatal(err)
 	}
 
 	// Open shell-history.json
-	jsonFile, err := os.Open(user.HomeDir + "/.config/shell-history.json")
+	jsonFile, err := os.Open(currentUser.HomeDir + "/.config/shell-history.json")
 
 	// if we os.Open returns an error log it.
 	if err != nil {
@@ -94,13 +94,13 @@ func connectInsecure(address string) (*grpc.ClientConn, error) {
 
 func getinformation(argsWithoutProg []string, commandExitCode int64) spb.Command {
 	var h spb.Command
-	user, err := user.Current()
+	currentUser, err := user.Current()
 	if err != nil {
 		log.Fatal(err)
 	}
 	h.Hostname, _ = os.Hostname()
 	h.Timestamp = time.Now().UTC().Unix()
-	h.Username = user.Username
+	h.Username = currentUser.Username
 	h.Cwd, err = os.Getwd()
 	h.Oldpwd = os.Getenv("OLDPWD")
 	h.Command = argsWithoutProg

--- a/main.go
+++ b/main.go
@@ -73,7 +73,7 @@ type Transformer interface {
 	transform(input string) (output string)
 }
 
-// Represents a filter that maps a regex key to a regex transformation.
+// Represents a filter that maps a regex key to a regex transform.
 type Redactor map[string]string
 
 // Transforms source string to and output string when it matches a defined
@@ -86,7 +86,7 @@ func (redactor Redactor) transform(source string) (result string) {
 		if err != nil {
 			log.Fatalf("Redactor key %q is an invalid regexp", key)
 		}
-		result = regex.ReplaceAllString(source, value)
+		result = regex.ReplaceAllString(result, value)
 	}
 
 	return

--- a/main_test.go
+++ b/main_test.go
@@ -42,3 +42,23 @@ func Test_getinformation(t *testing.T) {
 		})
 	}
 }
+
+func TestRedactionFilter(t *testing.T) {
+	t.Run("leave alone commands that do not match redaction filter", func(t *testing.T) {
+		testCases := []struct{ matcher, transformation, source, expected string }{
+			{"bob", "sam", "ls /sam", "ls /sam"},
+			{"sam", "bob", "command bob", "command bob"},
+		}
+		for _, testCase := range testCases {
+			var redactionFilter Transformer = &RedactionFilter{
+				testCase.matcher: testCase.transformation,
+			}
+			t.Run(testCase.source, func(t *testing.T) {
+				actual := redactionFilter.transform(testCase.source)
+				if actual != testCase.expected {
+					t.Errorf("Expected %q, got %q", testCase.expected, actual)
+				}
+			})
+		}
+	})
+}


### PR DESCRIPTION
In response to #9, I have made an attempt at implementing the ability to specify redaction transformations on executed commands.

The changes to the user interface are pretty minimal. In the _~/.config/shell-history.json_ file, you can specify redaction logic like so:

```json
{
  "redactors": {
    "(--password)=\w+": "$1=REDACTED",
    "Trump": "POTUS"
  }
}
```

Then, for every argument of the shell command being stored, the argument will be compared against the dictionary of redactors, performing regular expression search and replaces as specified. The key is used for the regular expression search string, and the value is used for the replacement logic.

Please take a look and let me know if you have any concerns. I've unit-tested the new logic, but I didn't actually perform a manual end-to-end test, so I can't verify if it works (though I think it should).