### PR TITLE
Add cert generation to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,18 @@
+FROM golang:1.13-alpine AS certgen
+
+RUN apk add git
+WORKDIR /tmp
+RUN cd /tmp && git clone https://github.com/square/certstrap && cd certstrap && go build
+RUN /tmp/certstrap/certstrap --depot-path /tmp/certs init --passphrase "" --common-name localhost
+
 FROM phusion/baseimage
 
 CMD ["/sbin/my_init"]
 
-RUN mkdir -p /app/certs 
+RUN mkdir -p /app/certs
 WORKDIR /app
 
-RUN apt  update
+RUN apt update
 RUN apt install -y python3-dev gcc python3-pip libmysqlclient-dev
 
 COPY requirements.txt requirements.txt
@@ -13,9 +20,9 @@ COPY history/history.proto history/history.proto
 
 RUN pip3 install --upgrade pip
 RUN pip3 install -r requirements.txt
-RUN python3 -m grpc_tools.protoc -Ihistory/ --python_out=/app/ --grpc_python_out=/app/ history/history.proto 
+RUN python3 -m grpc_tools.protoc -Ihistory/ --python_out=/app/ --grpc_python_out=/app/ history/history.proto
 
-COPY certs/* /app/certs/
+COPY --from=certgen /tmp/certs/* /app/certs/
 COPY backend/* /app/
 COPY start_server.sh /etc/service/server/run
 COPY start_django.sh /etc/service/django/run


### PR DESCRIPTION
This PR fixes docker image build by adding certificate generation to Dockerfile.
Previously `docker build` was failing on line 18 (`COPY certs/* /app/certs/`), since there were no certs.